### PR TITLE
Minor refactoring around :data

### DIFF
--- a/app/src/main/java/dk/nodes/template/injection/modules/RestModule.kt
+++ b/app/src/main/java/dk/nodes/template/injection/modules/RestModule.kt
@@ -8,10 +8,10 @@ import dagger.Provides
 import dk.nodes.nstack.kotlin.NStack
 import dk.nodes.nstack.kotlin.provider.NMetaInterceptor
 import dk.nodes.template.BuildConfig
-import dk.nodes.template.network.Api
-import dk.nodes.template.network.util.BufferedSourceConverterFactory
-import dk.nodes.template.network.util.DateDeserializer
-import dk.nodes.template.network.util.ItemTypeAdapterFactory
+import dk.nodes.template.data.network.Api
+import dk.nodes.template.data.network.util.BufferedSourceConverterFactory
+import dk.nodes.template.data.network.util.DateDeserializer
+import dk.nodes.template.data.network.util.ItemTypeAdapterFactory
 import okhttp3.OkHttpClient
 import retrofit2.Converter
 import retrofit2.Retrofit

--- a/app/src/main/java/dk/nodes/template/injection/modules/RestRepositoryBinding.kt
+++ b/app/src/main/java/dk/nodes/template/injection/modules/RestRepositoryBinding.kt
@@ -2,7 +2,7 @@ package dk.nodes.template.injection.modules
 
 import dagger.Binds
 import dagger.Module
-import dk.nodes.template.network.RestPostRepository
+import dk.nodes.template.data.network.RestPostRepository
 import dk.nodes.template.domain.repositories.PostRepository
 import javax.inject.Singleton
 

--- a/app/src/main/java/dk/nodes/template/injection/modules/StorageBindingModule.kt
+++ b/app/src/main/java/dk/nodes/template/injection/modules/StorageBindingModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import dk.nodes.template.domain.managers.PrefManager
 import dk.nodes.template.domain.managers.ThemeManager
 import dk.nodes.template.domain.managers.ThemeManagerImpl
-import dk.nodes.template.storage.PrefManagerImpl
+import dk.nodes.template.data.storage.PrefManagerImpl
 import javax.inject.Singleton
 
 @Module

--- a/data/src/main/java/dk/nodes/template/data/network/Api.kt
+++ b/data/src/main/java/dk/nodes/template/data/network/Api.kt
@@ -1,4 +1,4 @@
-package dk.nodes.template.network
+package dk.nodes.template.data.network
 
 import dk.nodes.template.domain.entities.Post
 import retrofit2.Response

--- a/data/src/main/java/dk/nodes/template/data/network/RestPostRepository.kt
+++ b/data/src/main/java/dk/nodes/template/data/network/RestPostRepository.kt
@@ -1,4 +1,4 @@
-package dk.nodes.template.network
+package dk.nodes.template.data.network
 
 import dk.nodes.template.domain.entities.Post
 import dk.nodes.template.domain.repositories.PostRepository

--- a/data/src/main/java/dk/nodes/template/data/network/util/BufferedSourceConverterFactory.kt
+++ b/data/src/main/java/dk/nodes/template/data/network/util/BufferedSourceConverterFactory.kt
@@ -1,4 +1,4 @@
-package dk.nodes.template.network.util
+package dk.nodes.template.data.network.util
 
 import okhttp3.ResponseBody
 import okio.BufferedSource

--- a/data/src/main/java/dk/nodes/template/data/network/util/DateDeserializer.kt
+++ b/data/src/main/java/dk/nodes/template/data/network/util/DateDeserializer.kt
@@ -1,4 +1,4 @@
-package dk.nodes.template.network.util
+package dk.nodes.template.data.network.util
 
 import com.google.gson.JsonDeserializationContext
 import com.google.gson.JsonDeserializer

--- a/data/src/main/java/dk/nodes/template/data/network/util/ItemTypeAdapterFactory.kt
+++ b/data/src/main/java/dk/nodes/template/data/network/util/ItemTypeAdapterFactory.kt
@@ -1,4 +1,4 @@
-package dk.nodes.template.network.util
+package dk.nodes.template.data.network.util
 
 import com.google.gson.Gson
 import com.google.gson.JsonElement

--- a/data/src/main/java/dk/nodes/template/data/storage/PrefManagerImpl.kt
+++ b/data/src/main/java/dk/nodes/template/data/storage/PrefManagerImpl.kt
@@ -1,9 +1,8 @@
-package dk.nodes.template.storage
+package dk.nodes.template.data.storage
 
 import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
-import androidx.preference.PreferenceManager
 import dk.nodes.template.domain.managers.PrefManager
 import javax.inject.Inject
 


### PR DESCRIPTION
- Fix path: `src/main/java/dk/nodes/template/data` so we have clean imports like `dk.nodes.template.data`
  - similar to `dk.nodes.template.domain`
  - similar to `dk.nodes.template.presentation` 
- Move `/storage/PrefManagerImpl` from `:app` to `:data`